### PR TITLE
Upgrade dependencies to reduce security risk

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -2,8 +2,8 @@
 # Entries are ordered alphabetically by group, then artifact
 # Entries are in groups/blocks based on matching group IDs
 
-com.amazonaws:aws-java-sdk-sns=1.11.405
-com.amazonaws:aws-java-sdk-ssm=1.11.409
+com.amazonaws:aws-java-sdk-sns=1.11.423
+com.amazonaws:aws-java-sdk-ssm=1.11.423
 com.amazonaws:aws-lambda-java-core=1.2.0
 com.amazonaws:aws-lambda-java-events=2.2.2
 com.amazonaws:aws-lambda-java-log4j2=1.0.0
@@ -16,7 +16,7 @@ com.squareup.okhttp3:okhttp=3.11.0
 
 commons-codec:commons-codec=1.10
 
-io.jsonwebtoken:jjwt=0.7.0
+io.jsonwebtoken:jjwt=0.9.1
 
 net.sourceforge.nekohtml:nekohtml=1.9.21
 


### PR DESCRIPTION
CoPilot flagged 3 high-risk components. Two are jackson, pulled into the test-runtime or runtime by other dependencies, which are upgraded here.

One may be an issue with how we deal with vulnerabilities - we may read the version-level vulns to be consistent, but if origin data is different (ex: redhat release) we still flag it. We are using bouncycastle redhat-2 (1.4.6), but are flagged as using 1.46, which is vulnerable