### PR TITLE
#71 : add configuration instructions to homepage

### DIFF
--- a/html/dev.html
+++ b/html/dev.html
@@ -46,12 +46,12 @@ releaseNoteFiles:
                     <li><span class="highlight">productionFiles</span> - Describes what files to consider as production files</li>
                     <ul>
                       <li><span class="highlight">include</span> - A list of case-insensitive patterns to consider as production files</li>
-                      <li><span class="highlight">include</span> - A list of case-insensitive patterns to exclude from production files</li>
+                      <li><span class="highlight">exclude</span> - A list of case-insensitive patterns to exclude from production files</li>
                     </ul>
                     <li><span class="highlight">releaseNoteFiles</span> - Describes what files to consider as release notes files</li>
                     <ul>
                       <li><span class="highlight">include</span> - A list of case-insensitive patterns to consider as release notes files</li>
-                      <li><span class="highlight">include</span> - A list of case-insensitive patterns to exclude from release notes files</li>
+                      <li><span class="highlight">exclude</span> - A list of case-insensitive patterns to exclude from release notes files</li>
                     </ul>
                   </ul>
                   <p>All patterns from the instructions above are Java PathMatcher <a href="https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)">Glob Syntax</a></p>

--- a/html/dev.html
+++ b/html/dev.html
@@ -23,6 +23,43 @@
             <a target="_blank" href="https://github.com/apps/chronicler-dev" class="button">Install Now</a><br>
             <img src="images/checks.png">
             <p>Chronicler adds a check to your GitHub pull requests, which fails if production code was changed without a matching update to the release notes</p>
+            <div id="configuration">
+              <h1>Configuration</h1>
+              <p>You can configure Chronicler to customize what is considered a production file and what is considered a release notes file. Create a YAML file at <span class="highlight">/.starchart-labs/chronicler.yml</span> in your repository. This is not required, and the default values, shown below, have been selected to cover general cases.</p>
+              <div id="config-side-by-side">
+                <div class="tearaway">
+<pre>
+productionFiles:
+   include:
+      - '**/src/**'
+   exclude:
+      - '**/test/**'
+releaseNoteFiles:
+   include:
+      - '**/CHANGE*LOG*'
+      - '**/RELEASE*NOTES*'
+</pre>
+                </div>
+                <div class="instructions">
+                  <p>The configuration shown is the default values. Here is the YAML structure supported for configuration:</p>
+                  <ul>
+                    <li><span class="highlight">productionFiles</span> - Describes what files to consider as production files</li>
+                    <ul>
+                      <li><span class="highlight">include</span> - A list of case-insensitive patterns to consider as production files</li>
+                      <li><span class="highlight">include</span> - A list of case-insensitive patterns to exclude from production files</li>
+                    </ul>
+                    <li><span class="highlight">releaseNoteFiles</span> - Describes what files to consider as release notes files</li>
+                    <ul>
+                      <li><span class="highlight">include</span> - A list of case-insensitive patterns to consider as release notes files</li>
+                      <li><span class="highlight">include</span> - A list of case-insensitive patterns to exclude from release notes files</li>
+                    </ul>
+                  </ul>
+                  <p>All patterns from the instructions above are Java PathMatcher <a href="https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)">Glob Syntax</a></p>
+                </div>
+              </div>
+            </div>
+        </div>
+
         </div>
 
         <div id="footer">

--- a/html/production.html
+++ b/html/production.html
@@ -43,12 +43,12 @@ releaseNoteFiles:
                     <li><span class="highlight">productionFiles</span> - Describes what files to consider as production files</li>
                     <ul>
                       <li><span class="highlight">include</span> - A list of case-insensitive patterns to consider as production files</li>
-                      <li><span class="highlight">include</span> - A list of case-insensitive patterns to exclude from production files</li>
+                      <li><span class="highlight">exclude</span> - A list of case-insensitive patterns to exclude from production files</li>
                     </ul>
                     <li><span class="highlight">releaseNoteFiles</span> - Describes what files to consider as release notes files</li>
                     <ul>
                       <li><span class="highlight">include</span> - A list of case-insensitive patterns to consider as release notes files</li>
-                      <li><span class="highlight">include</span> - A list of case-insensitive patterns to exclude from release notes files</li>
+                      <li><span class="highlight">exclude</span> - A list of case-insensitive patterns to exclude from release notes files</li>
                     </ul>
                   </ul>
                   <p>All patterns from the instructions above are Java PathMatcher <a href="https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)">Glob Syntax</a></p>

--- a/html/production.html
+++ b/html/production.html
@@ -20,6 +20,41 @@
             <a target="_blank" href="https://github.com/apps/chronicler-by-starchart-labs" class="button">Install Now</a><br>
             <img src="images/checks.png">
             <p>Chronicler adds a check to your GitHub pull requests, which fails if production code was changed without a matching update to the release notes</p>
+            <div id="configuration">
+              <h1>Configuration</h1>
+              <p>You can configure Chronicler to customize what is considered a production file and what is considered a release notes file. Create a YAML file at <span class="highlight">/.starchart-labs/chronicler.yml</span> in your repository. This is not required, and the default values, shown below, have been selected to cover general cases.</p>
+              <div id="config-side-by-side">
+                <div class="tearaway">
+<pre>
+productionFiles:
+   include:
+      - '**/src/**'
+   exclude:
+      - '**/test/**'
+releaseNoteFiles:
+   include:
+      - '**/CHANGE*LOG*'
+      - '**/RELEASE*NOTES*'
+</pre>
+                </div>
+                <div class="instructions">
+                  <p>The configuration shown is the default values. Here is the YAML structure supported for configuration:</p>
+                  <ul>
+                    <li><span class="highlight">productionFiles</span> - Describes what files to consider as production files</li>
+                    <ul>
+                      <li><span class="highlight">include</span> - A list of case-insensitive patterns to consider as production files</li>
+                      <li><span class="highlight">include</span> - A list of case-insensitive patterns to exclude from production files</li>
+                    </ul>
+                    <li><span class="highlight">releaseNoteFiles</span> - Describes what files to consider as release notes files</li>
+                    <ul>
+                      <li><span class="highlight">include</span> - A list of case-insensitive patterns to consider as release notes files</li>
+                      <li><span class="highlight">include</span> - A list of case-insensitive patterns to exclude from release notes files</li>
+                    </ul>
+                  </ul>
+                  <p>All patterns from the instructions above are Java PathMatcher <a href="https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)">Glob Syntax</a></p>
+                </div>
+              </div>
+            </div>
         </div>
 
         <div id="footer">

--- a/html/styles/index.css
+++ b/html/styles/index.css
@@ -75,7 +75,7 @@ a:active {
     margin-top: 30px;
 }
 #body p {
-    margin-top: 15px;
+    margin: 15px 5%;
 }
 
 a.button {
@@ -91,10 +91,71 @@ a.button:hover {
     background-color: #56586d;
 }
 
+#configuration {
+  font-size: 1.1rem;
+  margin: 30px 5%;
+  text-align: left;
+  padding: 50px;
+}
+
+#configuration p {
+  margin: 0;
+}
+
+h1 {
+  margin-top: 0;
+}
+
+#config-side-by-side {
+  display: flex;
+  padding: 20px;
+}
+
+.tearaway {
+  background-color: #c4b097;
+  background-image: url('../images/noise.png');
+  padding: 5px 15px;
+  position: relative;
+  flex: 1;
+  margin-right: 20px;
+}
+.tearaway:before,
+.tearaway:after {
+  content: ""; height: 4px;
+  position: absolute;
+  left: 0;
+  right: 0;
+  clip-path: polygon(0% 0%, 5%  100%, 10% 0%, 15%  100%, 20% 0%, 25% 100%, 30% 0%, 35%  100%, 40% 0%, 45%  100%, 50% 0%, 55%  100%, 60% 0%, 65%  100%, 70% 0%, 75%  100%, 80% 0%, 85%  100%, 90% 0%, 95%  100%, 100% 0%);
+  -webkit-clip-path: polygon(0% 0%, 5%  100%, 10% 0%, 15%  100%, 20% 0%, 25% 100%, 30% 0%, 35%  100%, 40% 0%, 45%  100%, 50% 0%, 55%  100%, 60% 0%, 65%  100%, 70% 0%, 75%  100%, 80% 0%, 85%  100%, 90% 0%, 95%  100%, 100% 0%);
+}
+.tearaway:before {
+  background-color: white;
+  top: -1px;
+}
+.tearaway:after {
+  background-color: #c4b097;
+  background-image: url('../images/noise.png');
+  bottom: -4px;
+}
+
+.instructions {
+  flex: 2;
+}
+
+.highlight {
+  font-family: monospace;
+  color: #444;
+  background-color: #ededed;
+  padding: 2px;
+}
+
+li {
+  margin-bottom: 5px;
+}
+
 #footer {
-    position: absolute;
     width: 100%;
-    bottom: 25px;
+    margin: 25px;
     font-size: 0.9rem;
     font-family: sans-serif;
 }


### PR DESCRIPTION
This adds a section to the end of the page describing how to configure Chronicler.
![image](https://user-images.githubusercontent.com/1371666/52246167-c96a7e00-28b2-11e9-8c7c-16defa655c44.png)
