### PR TITLE
GH-81 Add synchronize to list of actions sent for processing

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Replaced local webhook verifier with calamari-core implementation
 - Refactored use pattern of configuration file reader
 - Moved machete project to machete-additions to allow creation of common library without overlap
+- Fixed GH-81, allowing the Chronicler pull request status check to persist after merge conflict resolution
 
 ## [0.2.0]
 ### Added

--- a/github-model/src/main/java/org/starchartlabs/chronicler/github/model/webhook/PullRequestEvent.java
+++ b/github-model/src/main/java/org/starchartlabs/chronicler/github/model/webhook/PullRequestEvent.java
@@ -38,7 +38,7 @@ public class PullRequestEvent {
 
     private static final String EVENT_TYPE = "pull_request";
 
-    private static final Collection<String> FILE_CHANGE_TYPES = Stream.of("opened", "edited")
+    private static final Collection<String> COMMIT_CHANGE_TYPES = Stream.of("opened", "edited", "synchronize")
             .collect(Collectors.toSet());
 
     // PR id (.pull_request.id, number)
@@ -116,8 +116,8 @@ public class PullRequestEvent {
         return headCommitSha;
     }
 
-    public boolean isFileChangeType() {
-        return FILE_CHANGE_TYPES.contains(getAction());
+    public boolean isCommitChangeType() {
+        return COMMIT_CHANGE_TYPES.contains(getAction());
     }
 
     @Override

--- a/webhook-handler/src/main/java/org/starchartlabs/chronicler/webhook/handler/Handler.java
+++ b/webhook-handler/src/main/java/org/starchartlabs/chronicler/webhook/handler/Handler.java
@@ -121,7 +121,7 @@ public class Handler implements RequestHandler<APIGatewayProxyRequestEvent, APIG
             logger.info("Received pull request event ({}, pr:{})", event.getLoggableRepositoryName(),
                     event.getAction());
 
-            if (event.isFileChangeType()) {
+            if (event.isCommitChangeType()) {
                 result = new GitHubPullRequestEvent(
                         event.getNumber(),
                         event.getLoggableRepositoryName(),


### PR DESCRIPTION
Add "synchronize" to supported actions to keep chronicler status check
existing after a merge conflict is resolved by a user