### PR TITLE
GH-92 Make metric namespace configurable per deployment

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## Changed
+- GH-92: Made the metric installations data counts are recorded to configurable per deployment
 
 ## [0.2.2]
 ## Changed

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ## Changed
-- GH-92: Made the metric installations data counts are recorded to configurable per deployment
+- GH-92: Made the namespace of the metric for installations counts configurable per deployment
 
 ## [0.2.2]
 ## Changed

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,6 +1,5 @@
 # For full config options, check the docs: docs.serverless.com
 
-# TODO Document manual setup (secure parameter store values, github app, etc) required before deploy
 # GitHub App
 # CNAME for URL (Google Domains)
 # /${self:provider.stage}/${self:service}/github/webhook-secret (encrypted)
@@ -75,7 +74,6 @@ package:
   individually: true
 
 # TODO external various names and keys to variables
-# TODO Figure out resource statement for putting metric data
 functions:
   webhook-handler:
     package:
@@ -100,6 +98,7 @@ functions:
     environment:
         GITHUB_WEBHOOK_SECRET_SSM: /${self:provider.stage}/${self:service}/github/webhook-secret
         SNS_TOPIC_ARN: { Fn::Join: [":", ["arn:aws:sns", { "Ref": "AWS::Region" }, { "Ref" : "AWS::AccountId" }, "${self:custom.topic.diff}" ] ]  }
+        METRIC_NAMESPACE: ${self:service}/${self:provider.stage}
     events:
         - http:
             path: github/webhooks

--- a/webhook-handler/src/main/java/org/starchartlabs/chronicler/webhook/handler/Handler.java
+++ b/webhook-handler/src/main/java/org/starchartlabs/chronicler/webhook/handler/Handler.java
@@ -50,6 +50,8 @@ public class Handler implements RequestHandler<APIGatewayProxyRequestEvent, APIG
 
     private static final String SNS_TOPIC_ARN = System.getenv("SNS_TOPIC_ARN");
 
+    private static final String METRIC_NAMESPACE = System.getenv("METRIC_NAMESPACE");;
+
     private static final AmazonSNS SNS_CLIENT = AmazonSNSClientBuilder.defaultClient();
 
     private static final AmazonCloudWatch CLOUDWATCH_CLIENT = AmazonCloudWatchClientBuilder.defaultClient();
@@ -165,6 +167,8 @@ public class Handler implements RequestHandler<APIGatewayProxyRequestEvent, APIG
     }
 
     private void recordInstallation(int installations) {
+        logger.info("Recording {} installations to AWS namespace {}", installations, METRIC_NAMESPACE);
+
         Dimension dimension = new Dimension()
                 .withName("INSTALLATIONS")
                 .withValue("REPOSITORIES");
@@ -175,9 +179,8 @@ public class Handler implements RequestHandler<APIGatewayProxyRequestEvent, APIG
                 .withValue(Integer.valueOf(installations).doubleValue())
                 .withDimensions(dimension);
 
-        // TODO romeara setup namespace as an env variable
         PutMetricDataRequest request = new PutMetricDataRequest()
-                .withNamespace("chronicler/dev")
+                .withNamespace(METRIC_NAMESPACE)
                 .withMetricData(datum);
 
         CLOUDWATCH_CLIENT.putMetricData(request);


### PR DESCRIPTION
Change the namespace for AWS metrics to an environment variable,
allowing separation based on the deployment and stage