### PR TITLE
98 : add badge area to homepage

### DIFF
--- a/html/dev.html
+++ b/html/dev.html
@@ -28,6 +28,7 @@
               <h1>Tell The World</h1>
               <p>Let people visiting your project know that you keep your changelogs up-to-date with this badge! Here are some samples for adding it to a README</p>
               <img src="images/changelog-chronicler-success.svg">
+              <p class="fine-print">Badge image generated using <a target="_blank" href="https://shields.io">shields.io</a></p>
               <div class="tearaway">
 <pre>
 README.md:

--- a/html/dev.html
+++ b/html/dev.html
@@ -23,7 +23,35 @@
             <a target="_blank" href="https://github.com/apps/starchart-labs-chronicler-dev" class="button">Install Now</a><br>
             <img src="images/checks.png">
             <p>Chronicler adds a check to your GitHub pull requests, which fails if production code was changed without a matching update to the release notes</p>
-            <div id="configuration">
+
+            <div class="infoblob" id="get-badge">
+              <h1>Tell The World</h1>
+              <p>Let people visiting your project know that you keep your changelogs up-to-date with this badge! Here are some samples for adding it to a README</p>
+              <img src="images/changelog-chronicler-success.svg">
+              <div class="tearaway">
+<pre>
+README.md:
+
+[![Changelog validated by Chronicler](https://chronicler.starchartlabs.org/images/changelog-chronicler-success.svg)](https://chronicler.starchartlabs.org/)
+
+
+HTML:
+
+&lt;a href="https://chronicler.starchartlabs.org/"&gt;
+  &lt;img src="https://chronicler.starchartlabs.org/images/changelog-chronicler-success.svg" alt="Changelog validated by Chronicler"&gt;
+&lt;/a&gt;
+
+
+reStructuredText:
+
+.. image:: https://chronicler.starchartlabs.org/images/changelog-chronicler-success.svg
+    :target: https://chronicler.starchartlabs.org/
+    :alt: Changelog validated by Chronicler
+
+</pre>
+              </div>
+            </div>
+            <div class="infoblob" id="configuration">
               <h1>Configuration</h1>
               <p>You can configure Chronicler to customize what is considered a production file and what is considered a release notes file. Create a YAML file at <span class="highlight">/.starchart-labs/chronicler.yml</span> in your repository. This is not required, and the default values, shown below, have been selected to cover general cases.</p>
               <div id="config-side-by-side">

--- a/html/production.html
+++ b/html/production.html
@@ -24,6 +24,7 @@
               <h1>Tell The World</h1>
               <p>Let people visiting your project know that you keep your changelogs up-to-date with this badge! Here are some samples for adding it to a README</p>
               <img src="images/changelog-chronicler-success.svg">
+              <p class="fine-print">Badge image generated using <a target="_blank" href="https://shields.io">shields.io</a></p>
               <div class="tearaway">
 <pre>
 README.md:

--- a/html/production.html
+++ b/html/production.html
@@ -20,7 +20,34 @@
             <a target="_blank" href="https://github.com/apps/starchart-labs-chronicler" class="button">Install Now</a><br>
             <img src="images/checks.png">
             <p>Chronicler adds a check to your GitHub pull requests, which fails if production code was changed without a matching update to the release notes</p>
-            <div id="configuration">
+            <div class="infoblob" id="get-badge">
+              <h1>Tell The World</h1>
+              <p>Let people visiting your project know that you keep your changelogs up-to-date with this badge! Here are some samples for adding it to a README</p>
+              <img src="images/changelog-chronicler-success.svg">
+              <div class="tearaway">
+<pre>
+README.md:
+
+[![Changelog validated by Chronicler](https://chronicler.starchartlabs.org/images/changelog-chronicler-success.svg)](https://chronicler.starchartlabs.org/)
+
+
+HTML:
+
+&lt;a href="https://chronicler.starchartlabs.org/"&gt;
+  &lt;img src="https://chronicler.starchartlabs.org/images/changelog-chronicler-success.svg" alt="Changelog validated by Chronicler"&gt;
+&lt;/a&gt;
+
+
+reStructuredText:
+
+.. image:: https://chronicler.starchartlabs.org/images/changelog-chronicler-success.svg
+    :target: https://chronicler.starchartlabs.org/
+    :alt: Changelog validated by Chronicler
+
+</pre>
+              </div>
+            </div>
+            <div class="infoblob" id="configuration">
               <h1>Configuration</h1>
               <p>You can configure Chronicler to customize what is considered a production file and what is considered a release notes file. Create a YAML file at <span class="highlight">/.starchart-labs/chronicler.yml</span> in your repository. This is not required, and the default values, shown below, have been selected to cover general cases.</p>
               <div id="config-side-by-side">

--- a/html/styles/index.css
+++ b/html/styles/index.css
@@ -91,15 +91,19 @@ a.button:hover {
     background-color: #56586d;
 }
 
-#configuration {
+.infoblob {
   font-size: 1.1rem;
-  margin: 30px 5%;
+  margin: 10px 5%;
   text-align: left;
-  padding: 50px;
+  padding: 20px 50px 30px 50px;
 }
 
-#configuration p {
-  margin: 0;
+.infoblob p {
+  margin: 0 !important;
+}
+
+.infoblob img {
+  margin: 15px 0px;
 }
 
 h1 {
@@ -136,6 +140,10 @@ h1 {
   background-color: #c4b097;
   background-image: url('../images/noise.png');
   bottom: -4px;
+}
+
+.tearaway pre {
+  white-space: pre-wrap;
 }
 
 .instructions {

--- a/html/styles/index.css
+++ b/html/styles/index.css
@@ -106,6 +106,12 @@ a.button:hover {
   margin: 15px 0px;
 }
 
+p.fine-print {
+  font-size: 0.8rem;
+  color: #444;
+  padding-bottom: 10px;
+}
+
 h1 {
   margin-top: 0;
 }


### PR DESCRIPTION
Adds a new section to the homepage, above configuration:

![image](https://user-images.githubusercontent.com/1371666/54718766-ac6fce80-4b31-11e9-96f2-d228cc6d98ae.png)
