### PR TITLE
Resolves GH-102: Update headers to match declared Apache 2.0 license

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- GH-102 Fix file copyright headers to match the declared license of Apache 2.0
 
 ## [0.3.0]
 ### Changed

--- a/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/AnalysisResults.java
+++ b/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/AnalysisResults.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Sep 26, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.diff.analyzer;
 

--- a/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/AnalysisSettings.java
+++ b/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/AnalysisSettings.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Sep 26, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.diff.analyzer;
 

--- a/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/FileMatcher.java
+++ b/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/FileMatcher.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Jan 22, 2019 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.diff.analyzer;
 

--- a/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/PatternConditions.java
+++ b/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/PatternConditions.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Sep 26, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.diff.analyzer;
 

--- a/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/PullRequestAnalyzer.java
+++ b/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/PullRequestAnalyzer.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Sep 26, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.diff.analyzer;
 

--- a/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/aws/Handler.java
+++ b/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/aws/Handler.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Sep 17, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.diff.analyzer.aws;
 

--- a/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/configuration/AnalysisSettingsYaml.java
+++ b/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/configuration/AnalysisSettingsYaml.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Jan 21, 2019 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.diff.analyzer.configuration;
 

--- a/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/configuration/PatternConditionsYaml.java
+++ b/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/configuration/PatternConditionsYaml.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Jan 21, 2019 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.diff.analyzer.configuration;
 

--- a/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/exception/InvalidConfigurationException.java
+++ b/diff-analyzer/src/main/java/org/starchartlabs/chronicler/diff/analyzer/exception/InvalidConfigurationException.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Jan 22, 2019 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.diff.analyzer.exception;
 

--- a/diff-analyzer/src/test/java/org/starchartlabs/chronicler/test/diff/analyzer/AnalysisSettingsTest.java
+++ b/diff-analyzer/src/test/java/org/starchartlabs/chronicler/test/diff/analyzer/AnalysisSettingsTest.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Jan 22, 2019 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.test.diff.analyzer;
 

--- a/events/src/main/java/org/starchartlabs/chronicler/events/GitHubPullRequestEvent.java
+++ b/events/src/main/java/org/starchartlabs/chronicler/events/GitHubPullRequestEvent.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Sep 20, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.events;
 

--- a/github-model/src/main/java/org/starchartlabs/chronicler/github/model/Requests.java
+++ b/github-model/src/main/java/org/starchartlabs/chronicler/github/model/Requests.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Oct 1, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.github.model;
 

--- a/github-model/src/main/java/org/starchartlabs/chronicler/github/model/pullrequest/State.java
+++ b/github-model/src/main/java/org/starchartlabs/chronicler/github/model/pullrequest/State.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Oct 1, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.github.model.pullrequest;
 

--- a/github-model/src/main/java/org/starchartlabs/chronicler/github/model/pullrequest/StatusHandler.java
+++ b/github-model/src/main/java/org/starchartlabs/chronicler/github/model/pullrequest/StatusHandler.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Oct 1, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.github.model.pullrequest;
 

--- a/github-model/src/main/java/org/starchartlabs/chronicler/github/model/pullrequest/StatusRequest.java
+++ b/github-model/src/main/java/org/starchartlabs/chronicler/github/model/pullrequest/StatusRequest.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Oct 1, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.github.model.pullrequest;
 

--- a/github-model/src/main/java/org/starchartlabs/chronicler/github/model/webhook/InstallationEvent.java
+++ b/github-model/src/main/java/org/starchartlabs/chronicler/github/model/webhook/InstallationEvent.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Nov 19, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.github.model.webhook;
 

--- a/github-model/src/main/java/org/starchartlabs/chronicler/github/model/webhook/InstallationRepositoriesEvent.java
+++ b/github-model/src/main/java/org/starchartlabs/chronicler/github/model/webhook/InstallationRepositoriesEvent.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Nov 19, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.github.model.webhook;
 

--- a/github-model/src/main/java/org/starchartlabs/chronicler/github/model/webhook/PingEvent.java
+++ b/github-model/src/main/java/org/starchartlabs/chronicler/github/model/webhook/PingEvent.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Sep 20, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.github.model.webhook;
 

--- a/github-model/src/main/java/org/starchartlabs/chronicler/github/model/webhook/PullRequestEvent.java
+++ b/github-model/src/main/java/org/starchartlabs/chronicler/github/model/webhook/PullRequestEvent.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Sep 19, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.github.model.webhook;
 

--- a/webhook-handler/src/main/java/org/starchartlabs/chronicler/webhook/handler/Handler.java
+++ b/webhook-handler/src/main/java/org/starchartlabs/chronicler/webhook/handler/Handler.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Sep 14, 2018 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.webhook.handler;
 

--- a/webhook-handler/src/main/java/org/starchartlabs/chronicler/webhook/handler/WebhookEventConverter.java
+++ b/webhook-handler/src/main/java/org/starchartlabs/chronicler/webhook/handler/WebhookEventConverter.java
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) Mar 4, 2019 StarChart Labs Authors.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright 2019 StarChart-Labs Contributors (https://github.com/StarChart-Labs)
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.starchartlabs.chronicler.webhook.handler;
 


### PR DESCRIPTION
Previously, the auto-header settings for files were incorrectly set to
the copyright for the EPL license, which did not match the declared
Apache 2.0 license

These changes update the headers to match the intended Apache 2.0
licensing of the project