### PR TITLE
Resolves GH-103: Updates Calamari to 0.3.3 to address vulnerability

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - GH-102 Fix file copyright headers to match the declared license of Apache 2.0
+- GH-103 Update to Calamari 0.3.3 to address potential timing attack vulnerability
 
 ## [0.3.0]
 ### Changed

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -22,7 +22,7 @@ org.apache.logging.log4j:log4j-core=2.11.2
 org.apache.logging.log4j:log4j-slf4j-impl=2.11.2
 
 org.starchartlabs.alloy:alloy-core=0.4.1
-org.starchartlabs.calamari:calamari-core=0.3.2
+org.starchartlabs.calamari:calamari-core=0.3.3
 org.starchartlabs.machete:machete-sns=0.2.0
 org.starchartlabs.machete:machete-ssm=0.2.0
 


### PR DESCRIPTION
Update to Calamari 0.3.3, which addresses a potential security
vulnerability in webhook origin verification