### PR TITLE
Switch to openjdk8 for Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   
 after_success:
   - bash <(curl -s https://copilot.blackducksoftware.com/ci/travis/scripts/upload)


### PR DESCRIPTION
Licensing for Oracle JDK 8 has changed, and has become unreliable for installs in Travis. Switch to openjdk8 for more stable builds