### PR TITLE
Force root project name for consistent builds

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
+rootProject.name = 'chronicler'
+
 include 'events'
 include 'github-model'
 include 'webhook-handler'


### PR DESCRIPTION
Prevent the checkout directory name of the repository from affecting the root project name variable by explicitly specifying it in settings